### PR TITLE
Removed test scope for tcp.spec dependency so it can be used transitively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
       <groupId>org.reaktivity</groupId>
       <artifactId>nukleus-tcp.spec</artifactId>
       <version>${nukleus.tcp.spec.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Needed  to apply review feedback for https://github.com/reaktivity/nukleus-kafka.java/pull/3