### PR TITLE
Limit max fetch bytes

### DIFF
--- a/src/main/java/org/reaktivity/specification/kafka/internal/Functions.java
+++ b/src/main/java/org/reaktivity/specification/kafka/internal/Functions.java
@@ -19,7 +19,6 @@ import static java.lang.Long.highestOneBit;
 import static java.lang.Long.numberOfTrailingZeros;
 import static java.lang.System.currentTimeMillis;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.kaazing.k3po.lang.el.Function;
@@ -27,8 +26,6 @@ import org.kaazing.k3po.lang.el.spi.FunctionMapperSpi;
 
 public final class Functions
 {
-    private static final Random RANDOM = new Random();
-
     @Function
     public static short lengthAsShort(String value)
     {
@@ -47,7 +44,7 @@ public final class Functions
         byte[] bytes = new byte[length];
         for (int i = 0; i < length; i++)
         {
-            bytes[i] = (byte) RANDOM.nextInt(0x100);
+            bytes[i] = (byte) ThreadLocalRandom.current().nextInt(0x100);
         }
         return bytes;
     }

--- a/src/main/java/org/reaktivity/specification/kafka/internal/Functions.java
+++ b/src/main/java/org/reaktivity/specification/kafka/internal/Functions.java
@@ -19,6 +19,7 @@ import static java.lang.Long.highestOneBit;
 import static java.lang.Long.numberOfTrailingZeros;
 import static java.lang.System.currentTimeMillis;
 
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.kaazing.k3po.lang.el.Function;
@@ -26,6 +27,7 @@ import org.kaazing.k3po.lang.el.spi.FunctionMapperSpi;
 
 public final class Functions
 {
+    private static final Random RANDOM = new Random();
 
     @Function
     public static short lengthAsShort(String value)
@@ -37,6 +39,17 @@ public final class Functions
     public static int newRequestId()
     {
         return ThreadLocalRandom.current().nextInt();
+    }
+
+    @Function
+    public static byte[] randomBytes(int length)
+    {
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++)
+        {
+            bytes[i] = (byte) RANDOM.nextInt(0x100);
+        }
+        return bytes;
     }
 
     @Function

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.response.exceeds.requested.256.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.response.exceeds.requested.256.bytes/client.rpt
@@ -1,0 +1,158 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 54         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Fetch stream
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65
+write 1s
+write 5s
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write 256
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write 256
+
+read 384
+read ${newRequestId}
+read [0..4]
+read 0x01
+read 0x04s "test"
+read 1
+read 0
+read 0s
+read 1L
+read -1L
+read 0L
+read -1
+read 336       # length of record batch
+read 0L
+read 324       # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1
+read ${kafka:varint(18)}
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(-1)}
+read ${kafka:varint(256)}
+read [0..124]

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.response.exceeds.requested.256.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.response.exceeds.requested.256.bytes/server.rpt
@@ -1,0 +1,151 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 54        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Fetch stream
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65
+read 1s         # API key (fetch)
+read 5s         # API version
+read (int:requestId)
+read -1s        # client id
+read -1 
+read [0..4]     # max wait time millis
+read 1
+read 256        # max fetch bytes
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0
+read 0L
+read -1L
+read [0..4]      # max partition bytes
+
+read notify FETCH_REQUEST_RECEIVED
+
+write await WRITE_FETCH_RESPONSE
+
+# Kafka will exceed max fetch bytes to deliver at least one message
+write 384
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1         # number of partition responses
+write 0         # partition
+write 0s
+write 1L
+write -1L
+write 0L
+write -1
+write 336       # length of record batch
+write 0L
+write 324       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 0x01
+write ${kafka:varint(18)}
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(-1)}
+write ${kafka:varint(256)}  # value length
+write ${kafka:randomBytes(124)} # partial value, rest of response not written due to limited window 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.max.bytes.256/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.max.bytes.256/client.rpt
@@ -1,0 +1,201 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+connected
+
+write 21        # Size
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 107        # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 2        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+
+    read 0s     # error code
+    read 1      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 54         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Fetch stream
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 89        # Size
+write 1s        # API key (fetch)
+write 5s        # API version
+write ${newRequestId}
+write -1s       # client id
+write -1 
+write ${maximumWaitTime}
+write 1
+write 256
+write [0x00]
+write 1
+write 0x04s "test"
+write 2         # Number of partitions
+write 0         # Partition
+write 0x00L
+write -1L
+write 256       # max partition bytes
+write 1         # Partition
+write 0L
+write -1L
+write 256       # max partition bytes
+
+read 252        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 0x04s "test"
+read 2          # Number of partition responses
+    read 0      # Partition
+    read 0x00s
+    read 0x01L  # high_watermark
+    read -1L    # last_stable_offset
+    read 0L     # log_start_offset
+    read -1     # aborted_transactions (null)
+    read 77     # Length of the record batch
+                # Start of RecordBatch
+    read 0L     # First offset 
+    read 65     # Length
+    read 0      # Partition leader epoque
+    read [0x02] # Magic
+    read 0x4e8723aa         # CRC32
+    read 0s     # attributes
+    read 0      # last offset delta
+    read (long:timestamp)   # first timestamp
+    read ${timestamp}       # maximum timestamp
+    read -1L    # producer ID
+    read -1s    # producer epoque
+    read -1     # first sequence
+    read 1      # Number of records
+    read ${kafka:varint(15)} # Record length
+    read [0x00] # attributes
+    read ${kafka:varint(0)}  # timestamp delta
+    read ${kafka:varint(0)}  # offset delta
+    read ${kafka:varint(-1)} # key length
+    read ${kafka:varint(9)}  # value length
+    read "Hello one"         # value
+    read ${kafka:varint(0)}  # headers array length
+  
+    read 1      # Partition
+    read 0s
+    read 1L  # high_watermark
+    read -1L    # last_stable_offset
+    read 0L     # log_start_offset
+    read -1     # aborted_transactions (null)
+    read 77     # Length of the record batch
+                # Start of RecordBatch
+    read 0L     # First offset 
+    read 65     # Length
+    read 0      # Partition leader epoque
+    read [0x02] # Magic
+    read 0x4e8723aa          # CRC32
+    read 0s     # attributes
+    read 0      # last offset delta
+    read (long:timestamp)    # first timestamp
+    read ${timestamp}        # maximum timestamp
+    read -1L    # producer ID
+    read -1s    # producer epoque
+    read -1     # first sequence
+    read 1      # Number of records
+    read ${kafka:varint(15)} # Record length
+    read [0x00] # attributes
+    read ${kafka:varint(0)}  # timestamp delta
+    read ${kafka:varint(0)}  # offset delta
+    read ${kafka:varint(-1)} # key length
+    read ${kafka:varint(9)}  # value length
+    read "Hello two"         # value
+    read ${kafka:varint(0)}  # headers array length

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.max.bytes.256/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.max.bytes.256/server.rpt
@@ -1,0 +1,189 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 107       # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 2       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+    write 0s    # error code
+    write 1     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 54        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Fetch stream
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 89
+read 1s         # API key (fetch)
+read 5s         # API version
+read (int:requestId)
+read -1s        # client id
+read -1 
+read [0..4]     # max wait time millis
+read 1
+read 256        # max fetch bytes
+read [0x00]
+read 1
+read 4s "test"
+read 2          # Number of partitions
+read 0          # Partition
+read 0L      # fetch offset
+read -1L        # log start offset
+read 256        # max partition bytes
+read 1          # Partition
+read 0L
+read -1L
+read 256         # max partition bytes
+
+write 252
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 2         # Number of partition responses
+    write 0     # Partition
+    write 0s
+    write 1L    # high_watermark
+    write -1L   # last_stable_offset
+    write 0L    # log_start_offset
+    write -1    # aborted_transactions (null)
+    write 77    # Length of the record batch
+                # Start of RecordBatch
+    write 0L    # First offset 
+    write 65    # Length
+    write 0     # Partition leader epoque
+    write [0x02]            # Magic
+    write 0x4e8723aa        # CRC32
+    write 0s # attributes
+    write 0     # last offset delta
+    write ${newTimestamp}
+    write ${newTimestamp}
+    write -1L   # producer ID
+    write -1s   # producer epoque
+    write -1    # first sequence
+    write 1     # Number of records
+    write ${kafka:varint(15)} # Record length
+    write [0x00]              # attributes
+    write ${kafka:varint(0)}  # timestamp delta
+    write ${kafka:varint(0)}  # offset delta
+    write ${kafka:varint(-1)} # key length
+    write ${kafka:varint(9)}  # value length
+    write "Hello one"         # value
+    write ${kafka:varint(0)}  # headers array length
+  
+    write 1     # Partition
+    write 0s
+    write 1L # high_watermark
+    write -1L   # last_stable_offset
+    write 0L    # log_start_offset
+    write -1    # aborted_transactions (null)
+    write 77    # Length of the record batch
+                # Start of RecordBatch
+    write 0L    # First offset 
+    write 65    # Length
+    write 0     # Partition leader epoque
+    write [0x02]            # Magic
+    write 0x4e8723aa        # CRC32
+    write 0x00s # attributes
+    write 0     # last offset delta
+    write ${newTimestamp}
+    write ${newTimestamp}
+    write -1L   # producer ID
+    write -1s   # producer epoque
+    write -1    # first sequence
+    write 1     # Number of records
+    write ${kafka:varint(15)} # Record length
+    write [0x00]            # attributes
+    write ${kafka:varint(0)} # timestamp delta
+    write ${kafka:varint(0)} # offset delta
+    write ${kafka:varint(-1)} # key length
+    write ${kafka:varint(9)} # value length
+    write "Hello two"    # value
+    write ${kafka:varint(0)} # headers array length

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/zero.offset.messages.multiple.partitions.max.bytes.256/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/zero.offset.messages.multiple.partitions.max.bytes.256/client.rpt
@@ -1,0 +1,48 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext 2 ${kafka:varint(1)} ${kafka:varint(0)}
+read nukleus:data.ext -1
+read "Hello one"
+
+read nukleus:data.ext 2 ${kafka:varint(1)} ${kafka:varint(1)}
+read nukleus:data.ext -1
+read "Hello two"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/zero.offset.messages.multiple.partitions.max.bytes.256/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/zero.offset.messages.multiple.partitions.max.bytes.256/server.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext 2 ${kafka:varint(1)} ${kafka:varint(0)}
+write nukleus:data.ext -1
+write "Hello one"
+write flush
+
+write nukleus:data.ext 2 ${kafka:varint(1)} ${kafka:varint(1)}
+write nukleus:data.ext -1
+write "Hello two"
+write flush

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -282,6 +282,18 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/zero.offset.message.response.exceeds.requested.256.bytes/client",
+        "${scripts}/zero.offset.message.response.exceeds.requested.256.bytes/server"})
+    public void shouldHandleResponseExceedingMaxFetchBytes() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/ktable.message/client",
         "${scripts}/ktable.message/server"})
     public void shouldReceiveKtableMessage() throws Exception
@@ -408,6 +420,17 @@ public class FetchIT
         "${scripts}/zero.offset.messages.multiple.partitions/client",
         "${scripts}/zero.offset.messages.multiple.partitions/server"})
     public void shouldReceiveMessagesAtZeroOffsetMultiplePartitions() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/zero.offset.messages.multiple.partitions.max.bytes.256/client",
+        "${scripts}/zero.offset.messages.multiple.partitions.max.bytes.256/server"})
+    public void shouldReceiveMessagesAtZeroOffsetMultiplePartitionsMaxBytes256() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("ROUTED_SERVER");

--- a/src/test/java/org/reaktivity/specification/kafka/internal/FunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/kafka/internal/FunctionsTest.java
@@ -16,6 +16,7 @@
 package org.reaktivity.specification.kafka.internal;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.kaazing.k3po.lang.internal.el.ExpressionFactoryUtils.newExpressionFactory;
 
@@ -35,7 +36,6 @@ public class FunctionsTest
     @Before
     public void setUp() throws Exception
     {
-
         factory = newExpressionFactory();
         ctx = new ExpressionContext();
     }
@@ -47,6 +47,16 @@ public class FunctionsTest
         ValueExpression expression = factory.createValueExpression(ctx, expressionText, Integer.class);
         Object actual = expression.getValue(ctx);
         assertTrue(actual instanceof Integer);
+    }
+
+    @Test
+    public void shouldInvokeRandomBytes() throws Exception
+    {
+        String expressionText = "${kafka:randomBytes(10)}";
+        ValueExpression expression = factory.createValueExpression(ctx, expressionText, byte[].class);
+        Object actual = expression.getValue(ctx);
+        assertTrue(actual instanceof byte[]);
+        assertEquals(10, ((byte[]) actual).length);
     }
 
     @Test

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -327,6 +327,28 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/zero.offset.messages.multiple.partitions/client",
+        "${scripts}/zero.offset.messages.multiple.partitions/server"})
+    public void shouldReceiveMessagesAtZeroOffsetMultiplePartitions() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/zero.offset.messages.multiple.partitions.max.bytes.256/client",
+        "${scripts}/zero.offset.messages.multiple.partitions.max.bytes.256/server"})
+    public void shouldReceiveMessagesAtZeroOffsetMultiplePartitionsMaxBytes256() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/zero.offset.messagesets/client",
         "${scripts}/zero.offset.messagesets/server"})
     public void shouldReceiveMessageSetsAtZeroOffset() throws Exception


### PR DESCRIPTION
Added test cases:

1. to prove we are limiting maximum fetch bytes to 256 when that is the buffer slot capacity
2.  to prove we are handling the case where the response size exceeds maximum fetch bytes set on the request