### PR TITLE
Added a test for case where unsubscribe was causing assertion error 

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
@@ -1,0 +1,240 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId1 ${kafka:newRequestId()}
+property newRequestId2 ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 126        # Size
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 2          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null) 
+
+  read 2
+  read 7s "broker2"
+  read 9093
+  read -1s
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 2        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 2      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+
+    read 0s     # error code
+    read 1      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 54         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read notify METADATA_RECEIVED
+
+# Fetch stream 1 (partition 1)
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify FETCH_STREAM_ONE_CONNECTED
+
+write 65
+write 0x01s
+write 0x05s
+write ${newRequestId1}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 0x01
+write ${maximumBytes}
+write [0x00]
+write 1
+write 0x04s "test"
+write 1
+write 1         # Partition
+write 0x00L
+write -1L
+write ${maximumBytesTest0}
+
+read 140
+read ${newRequestId1}
+read [0..4]
+read 1
+read 0x04s "test"
+read 1
+read 1          # Partition
+read 0x00s
+read 0x01L
+read -1L
+read 0L
+read -1
+read 0x50
+read 0x00L
+read 0x44
+read 0x00
+read [0x02]
+read 0x4e8723aa
+read 0x00s
+read 0
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 0x01
+read ${kafka:varint(18)}
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(-1)}
+read ${kafka:varint(12)}
+read "Hello, world"
+read ${kafka:varint(0)}
+
+# Fetch stream 2 (partition 0)
+connect await FETCH_STREAM_ONE_CONNECTED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+
+connected
+
+write 0x41
+write 0x01s
+write 0x05s
+write ${newRequestId2}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 0x04s "test"
+write 1
+write 0         # Partition
+write 0x00L
+write -1L
+write ${maximumBytesTest0}
+
+read 145
+read ${newRequestId2}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s         # partition error code
+read 1L         # high watermark
+read -1L
+read 0L
+read -1
+read 85         # record set length
+read 0L
+read 73         # record batch length
+read 0x00
+read [0x02]
+read 0x4e8723aa
+read 0x00s
+read 0
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 0x01
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}     # key length
+read ${kafka:varint(5)}
+read "match"
+read ${kafka:varint(12)}
+read "Hello, again"
+read ${kafka:varint(0)}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
@@ -1,0 +1,227 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 126       # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 2         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+
+  write 2
+  write 7s "broker2"
+  write 9093
+  write -1s
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 2       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 2     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+    write 0s    # error code
+    write 1     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 54        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Fetch stream 1 (partition 1)
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65
+read 0x01s
+read 0x05s
+read (int:requestId1)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 0x01
+read 0x04s "test"
+read 1
+read 1          # partition
+read 0L
+read -1L
+read [0..4]
+
+read notify PARTITION_ONE_FETCH_REQUEST_RECEIVED
+
+write await CLIENT_TWO_UNSUBSCRIBED
+
+write 140
+write ${requestId1}
+write 0
+write 1         # Number of topic responses
+write 4s "test"
+write 1         # Number of partition responses
+write 1         # Partition
+write 0s        # partition error code
+write 1L        # high_watermark
+write -1L
+write 0L
+write -1
+write 80        # record set length
+write 0L        # first offset
+write 68        # record batch length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0x00s
+write 0
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 0x01
+write ${kafka:varint(18)}   # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(-1)}
+write ${kafka:varint(12)}
+write "Hello, world"
+write ${kafka:varint(0)}
+
+write notify PARTITION_ONE_RESPONSE_WRITTEN
+
+# Fetch stream 2 (partition 0)
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+connected
+
+read 65
+read 0x01s
+read 0x05s
+read (int:requestId2)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 0x04s "test"
+read 1
+read 0          # partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write await PARTITION_ONE_RESPONSE_WRITTEN
+
+write 145
+write ${requestId2}
+write 0
+write 1         # Number of responses
+write 4s "test"
+write 1         # Number of partition responses
+write 0         # Partition
+write 0s        # partition error code
+write 1L        # high_watermark
+write -1L
+write 0L        # log start offset
+write -1
+write 85        # record set length
+write 0L        # first offset
+write 73        # record batch length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 0x01
+write ${kafka:varint(23)}   # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(5)}    # key length
+write "match"
+write ${kafka:varint(12)}
+write "Hello, again"
+write ${kafka:varint(0)}
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.and.no.key.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.and.no.key.unsubscribe/client.rpt
@@ -1,0 +1,83 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5
+write nukleus:begin.ext "match"
+write nukleus:begin.ext [0x01]
+write nukleus:begin.ext 0     # force use of partition 0
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_CONNECTED
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5
+read nukleus:begin.ext "match"
+read nukleus:begin.ext [0x01]
+read nukleus:begin.ext 0
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(1)}
+read nukleus:data.ext -1
+read "Hello, again"
+
+connect await CLIENT_ONE_CONNECTED
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read notify CLIENT_TWO_CONNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+write await PARTITION_ONE_FETCH_REQUEST_RECEIVED
+
+read abort
+
+write notify CLIENT_TWO_HAS_WRITTEN_RESET
+
+
+
+
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.and.no.key.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.and.no.key.unsubscribe/server.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5
+read nukleus:begin.ext "match"
+read nukleus:begin.ext [0x01]
+read nukleus:begin.ext 0
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5
+write nukleus:begin.ext "match"
+write nukleus:begin.ext [0x01]
+write nukleus:begin.ext 0
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(1)}
+write nukleus:data.ext -1
+write "Hello, again"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write aborted
+
+

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -106,6 +106,18 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/fetch.key.and.no.key.multiple.partitions.unsubscribe/client",
+        "${scripts}/fetch.key.and.no.key.multiple.partitions.unsubscribe/server"})
+    public void shouldHandleUnsubscribeWithAndWithoutMessageKeysMultiplePartitions() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("CLIENT_TWO_UNSUBSCRIBED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/fetch.key.default.partioner.picks.partition.one/client",
         "${scripts}/fetch.key.default.partioner.picks.partition.one/server"})
     public void shouldReceiveMessageUsingFetchKeyAndDefaultPartitioner() throws Exception

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -150,6 +150,18 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/fetch.key.and.no.key.unsubscribe/client",
+        "${scripts}/fetch.key.and.no.key.unsubscribe/server"})
+    public void shouldHandleSubscribeWithAndWithoutKeyAndUnsubscribe() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.notifyBarrier("PARTITION_ONE_FETCH_REQUEST_RECEIVED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/fetch.key.and.hash.code.picks.partition.zero/client",
         "${scripts}/fetch.key.and.hash.code.picks.partition.zero/server"})
     public void shouldReceiveMessageUsingFetchKeyAndExplicitHashCode() throws Exception


### PR DESCRIPTION
The error was in NetworkTopic.getRequestedOffset (now renamed to getRequiredOffset). The  error happened when a fetch response comes in later and there a no longer consumers on that partition but there still are on others.  Specific steps for the test are as follows:

- topic has two partitions on different broker nodes
- client 1 subscribes to key pointing to partition 1
- client 2 subscribes to partitions 0 and 1 (no fetch key)
- fetch request goes out to both partitions (on the two broker connections)
- client 2 unsubscribes
- fetch response comes in for partition 0, which no longer has a subscriber, but there is still a subscriber on 1