### PR TITLE
Added tests for key offsets cache

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
@@ -1,0 +1,252 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 54         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Live fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify LIVE_FETCH_CONNECTED
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 172        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L        # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 112        # length of record set
+read 0L         # first offset
+read 100        # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+# Historical fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 172 # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 112        # record set length
+read 0L         # first offset
+read 100        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
@@ -1,0 +1,230 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 54        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 172       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L       # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 112       # length of record batch
+write 0L        # first offset
+write 100       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 2         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+# Historical fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 172       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 112       # length of record batch
+write 0L        # first offset
+write 100       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 2         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
@@ -1,0 +1,245 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 55         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Live fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify LIVE_FETCH_CONNECTED
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 172        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 03L        # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 112        # length of record batch
+read 0L         # first offset
+read 100        # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+# Historical fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 1L         # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 145        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 4L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 85         # length of record set
+read 1L         # first offset
+read 73         # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
@@ -174,18 +174,60 @@ read ${kafka:varint(12)}
 read "Hello second"
 read [0x00]
 
-# Historical fetch connection
-connect await METADATA_RECEIVED
-        ${networkConnect}
-  option nukleus:route ${newNetworkRouteRef}
-  option nukleus:window ${networkConnectWindow} 
-  option nukleus:transmission "duplex"
-  option nukleus:byteorder "network"
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 2L         # offset
+write -1L
+write ${maximumBytesTest0}
 
-write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+read 148        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 88         # length of record set
+read 2L         # first offset
+read 76         # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
 
-connected
-
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, third"
+read [0x00]
 
 
 write 65         # size
@@ -214,7 +256,7 @@ read 4s "test"
 read 1
 read 0          # Partition
 read 0s
-read 4L         # high watermark
+read 3L         # high watermark
 read -1L
 read 0L         # log start offset
 read -1         # aborted transactions (null)

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
@@ -178,7 +178,7 @@ read [0..4]
 
 read notify SECOND_LIVE_FETCH_REQUEST_RECEIVED
 
-write await DELIVER_SECOND_FETCH_RESPONSE
+write await DELIVER_SECOND_LIVE_FETCH_RESPONSE
 
 write 148       # Size
 write ${requestId}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
@@ -1,0 +1,274 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 55        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 172       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 03L       # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 112       # length of record batch
+write 0L        # first offset
+write 100       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 2         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+read 65         # Size
+read 1s         # Fetch
+read 5s         # version
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 2L         # offset
+read -1L
+read [0..4]
+
+read notify SECOND_LIVE_FETCH_REQUEST_RECEIVED
+
+write await DELIVER_SECOND_FETCH_RESPONSE
+
+write 148       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 88        # length of record set
+write 2L        # first offset
+write 76        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length 
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]                # headers
+
+read 65         # Size
+read 1s         # Fetch
+read 5s         # version
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 1L         # offset
+read -1L
+read [0..4]
+
+write 145       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 85        # length of record set
+write 1L        # first offset
+write 73        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.latest.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.latest.offset/client.rpt
@@ -1,0 +1,295 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 55         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Live fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 173        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 113
+read 0L         # first offset
+read 101        # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match1"
+read ${kafka:varint(12)}    # value length
+read "Hello second"
+read [0x00]
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 2L        # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 146        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 86        # length of record set
+read 2L         # first offset
+read 74         # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match2"
+read ${kafka:varint(12)}
+read "Hello, third"
+read [0x00]
+
+# Historical fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 1L        # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 146        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 86        # length of record set
+read 1L         # first offset
+read 74         # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match1"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.latest.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.latest.offset/server.rpt
@@ -1,0 +1,276 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 55        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 173      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 113       # length of record batch
+write 0L        # first offset
+write 101       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 2         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(6)}    # key length 
+write "match1"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 2L         # offset
+read -1L
+read [0..4]
+
+write await DELIVER_SECOND_LIVE_RESPONSE
+
+write 146      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 86        # length of record batch
+write 2L        # first offset
+write 74        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(6)}    # key length
+write "match2"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]                # headers
+
+# Historical fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 1L         # offset
+read -1L
+read [0..4]
+
+write 146      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 86        # length of record batch
+write 1L        # first offset
+write 74        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(6)}    # key length
+write "match1"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.live/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.live/client.rpt
@@ -1,0 +1,321 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 55         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Live fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify LIVE_FETCH_CONNECTED
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 199 # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 03L        # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 139         # length of record batch
+read 0L         # first offset
+read 127         # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 2          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 3          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(2)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, third"
+read [0x00]
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 3L         # offset
+write -1L
+write ${maximumBytesTest0}
+
+write notify DELIVER_SECOND_LIVE_RESPONSE
+
+read 145        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 4L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 85         # length of record set
+read 3L         # first offset
+read 73         # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello fourth"
+read [0x00]
+
+
+# Historical fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 1L
+write -1L
+write ${maximumBytesTest0}
+
+read 172 # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 112        # length of record set
+read 1L         # first offset
+read 100        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(23)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(5)}     # key length
+read "match"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, third"
+read [0x00]
+

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.live/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.live/server.rpt
@@ -1,0 +1,299 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 55        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 199       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 03L       # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 139       # length of record batch
+write 0L        # first offset
+write 127       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 2         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 3         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(2)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]                # headers
+
+read 65         # Size
+read 1s         # Fetch
+read 5s         # version
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 3L         # offset
+read -1L
+read [0..4]
+
+write await DELIVER_SECOND_LIVE_RESPONSE
+
+write 145       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 4L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 85        # length of record set
+write 3L        # first offset
+write 73        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(5)}    # key length
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello fourth"
+write [0x00]
+
+
+# Historical fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s         # version
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 1L         # offset
+read -1L
+read [0..4]
+
+write 172       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 112       # length of record set
+write 1L        # first offset
+write 100       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 2         # number of records
+
+write ${kafka:varint(23)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(5)}    # key length 
+write "match"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]                # headers
+
+

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.zero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.zero.offset/client.rpt
@@ -1,0 +1,307 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 55         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Live fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify LIVE_FETCH_CONNECTED
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 1L        # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 146        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 86        # length of record set
+read 1L         # first offset
+read 74         # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match1"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+# Historical fetch connection
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 1L        # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 146        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 2L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 86         # length of record set
+read 1L         # first offset
+read 74         # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match1"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+write 65         # size
+write 1s         # Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 198        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 138        # length of record set
+read 0L         # first offset
+read 126        # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 2          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 3          # number of records
+
+read ${kafka:varint(26)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(8)}     # key length
+read "no match"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match1"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+read ${kafka:varint(24)}    # record length
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(2)}     # offset delta
+read ${kafka:varint(6)}     # key length
+read "match2"
+read ${kafka:varint(12)}    # value length
+read "Hello, third"
+read [0x00]

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.zero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ktable.historical.uses.cached.key.then.zero.offset/server.rpt
@@ -1,0 +1,285 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 55        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 1L         # offset
+read -1L
+read [0..4]
+
+write 146      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 86        # length of record set
+write 1L        # first offset
+write 74        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(6)}    # key length
+write "match1"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+# Historical fetch connection
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 1L         # offset
+read -1L
+read [0..4]
+
+write 146      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 2L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 86        # length of record batch
+write 1L        # first offset
+write 74        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 1         # number of records
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(6)}    # key length
+write "match1"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 198      # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 138       # length of record set
+write 0L        # first offset
+write 126       # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 2         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 3         # number of records
+
+write ${kafka:varint(26)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(8)}    # key length
+write "no match"
+write ${kafka:varint(12)}   # value length
+write "Hello, world"
+write [0x00]                # headers
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(6)}    # key length 
+write "match1"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]                # headers
+
+write ${kafka:varint(24)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(2)}    # offset delta
+write ${kafka:varint(6)}    # key length
+write "match2"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]                # headers
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.historical.does.not.use.cached.key/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.historical.does.not.use.cached.key/client.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_CONNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext -1
+read "Hello second"
+
+write notify CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+
+connect await CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext -1
+read "Hello second"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.historical.does.not.use.cached.key/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/fetch.key.historical.does.not.use.cached.key/server.rpt
@@ -1,0 +1,69 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(1)}
+write nukleus:data.ext 4 "key1"
+write "Hello, world"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(1)}
+write nukleus:data.ext 4 "key1"
+write "Hello, world"
+write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/client.rpt
@@ -1,0 +1,75 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_CONNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 5 "match"
+read "Hello second"
+
+read abort
+
+write notify CLIENT_ONE_UNSUBSCRIBED
+
+connect await CONNECT_CLIENT_TWO
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+
+read notify CLIENT_TWO_CONNECTED
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 5 "match"
+read "Hello second"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
@@ -1,0 +1,71 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 5 "match"
+write "Hello second"
+write flush
+
+write aborted
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 5 "match"
+write "Hello second"
+write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.after.unsubscribe/server.rpt
@@ -65,7 +65,7 @@ write nukleus:begin.ext [0xFF]
 write nukleus:begin.ext 0
 write flush
 
-write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
 write nukleus:data.ext 5 "match"
 write "Hello second"
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.latest.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.latest.offset/client.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_COTomNNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 6 "match1"
+read "Hello second"
+
+write notify CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+
+connect await CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 6 "match1"
+read "Hello second"
+
+write notify CLIENT_TWO_RECEIVED_FIRST_MESSAGE
+
+connect await CLIENT_TWO_RECEIVED_FIRST_MESSAGE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match2"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match2"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read notify CLIENT_THREE_CONNECTED
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 6 "match2"
+read "Hello, third"
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.latest.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.latest.offset/server.rpt
@@ -1,0 +1,91 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 6 "match1"
+write "Hello second"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 6 "match1"
+write "Hello second"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match2"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match2"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
+write nukleus:data.ext 6 "match2"
+write "Hello, third"
+write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.live/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.live/client.rpt
@@ -1,0 +1,82 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_CONNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 5 "match"
+read "Hello second"
+
+write notify CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(4)}
+read nukleus:data.ext 5 "match"
+read "Hello fourth"
+
+connect await CONNECT_CLIENT_TWO
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 5 "match"
+read "Hello second"
+
+write notify CLIENT_TWO_RECEIVED_FIRST_MESSAGE
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(4)}
+read nukleus:data.ext 5 "match"
+read "Hello fourth"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.live/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.live/server.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
+write nukleus:data.ext 5 "match"
+write "Hello second"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(4)}
+write nukleus:data.ext 5 "match"
+write "Hello fourth"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 5 "match"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 5 "match"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
+write nukleus:data.ext 5 "match"
+write "Hello second"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(4)}
+write nukleus:data.ext 5 "match"
+write "Hello fourth"
+write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.zero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.zero.offset/client.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 8192
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(1)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+write notify CLIENT_ONE_CONNECTED
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(1)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 6 "match1"
+read "Hello second"
+
+write notify CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+
+connect await CLIENT_ONE_RECEIVED_FIRST_MESSAGE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 6 "match1"
+read "Hello second"
+
+write notify CLIENT_TWO_RECEIVED_FIRST_MESSAGE
+
+connect await CLIENT_TWO_RECEIVED_FIRST_MESSAGE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match2"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match2"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read notify CLIENT_THREE_CONNECTED
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 6 "match2"
+read "Hello, third"
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.zero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/ktable.historical.uses.cached.key.then.zero.offset/server.rpt
@@ -1,0 +1,91 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(1)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(1)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 6 "match1"
+write "Hello second"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match1"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match1"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 6 "match1"
+write "Hello second"
+write flush
+
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext 6 "match2"
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext 6 "match2"
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
+write nukleus:data.ext 6 "match2"
+write "Hello, third"
+write flush

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -374,6 +374,17 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.after.unsubscribe/client",
+        "${scripts}/ktable.historical.uses.cached.key.after.unsubscribe/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyAfterUnsubscribe() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/client",
         "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/server"})
     public void shouldReceiveKTableMessagesUsingCachedKeyThenLatestOffset() throws Exception

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -129,6 +129,17 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/fetch.key.historical.does.not.use.cached.key/client",
+        "${scripts}/fetch.key.historical.does.not.use.cached.key/server"})
+    public void shouldReceiveMessageFromNonCompactedTopicWithoutCachingKeyOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/fetch.key.multiple.matches.flow.controlled/client",
         "${scripts}/fetch.key.multiple.matches.flow.controlled/server"})
     public void shouldReceiveMessagesMatchingFetchKeyFlowControlled() throws Exception
@@ -358,6 +369,41 @@ public class FetchIT
         k3po.start();
         k3po.notifyBarrier("ROUTED_SERVER");
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenLatestOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("DELIVER_SECOND_LIVE_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.live/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.live/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenLive() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("DELIVER_SECOND_LIVE_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.zero.offset/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.zero.offset/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenZerotOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -380,6 +380,7 @@ public class FetchIT
     {
         k3po.start();
         k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("DELIVER_SECOND_LIVE_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -438,6 +438,17 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.after.unsubscribe/client",
+        "${scripts}/ktable.historical.uses.cached.key.after.unsubscribe/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyAfterUnsubscribe() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/client",
         "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/server"})
     public void shouldReceiveKTableMessagesUsingCachedKeyThenLatestOffset() throws Exception

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -208,6 +208,17 @@ public class FetchIT
     @Specification({
         "${scripts}/fetch.key.no.offsets.message/client",
         "${scripts}/fetch.key.no.offsets.message/server"})
+    public void shouldReceiveMessagesWithoutUsingKeyOffsetsCache() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/fetch.key.no.offsets.message/client",
+        "${scripts}/fetch.key.no.offsets.message/server"})
     public void shouldReceiveMessageUsingFetchKeyWithEmptyOffsetsArray() throws Exception
     {
         k3po.start();
@@ -419,6 +430,40 @@ public class FetchIT
         "${scripts}/zero.offset.messagesets.fanout/client",
         "${scripts}/zero.offset.messagesets.fanout/server"})
     public void shouldFanoutMessageSetsAtZeroOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.latest.offset/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenLatestOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.live/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.live/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenLive() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/ktable.historical.uses.cached.key.then.zero.offset/client",
+        "${scripts}/ktable.historical.uses.cached.key.then.zero.offset/server"})
+    public void shouldReceiveKTableMessagesUsingCachedKeyThenZerotOffset() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("ROUTED_CLIENT");

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -444,6 +444,7 @@ public class FetchIT
     {
         k3po.start();
         k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.finish();
     }
 


### PR DESCRIPTION
Test cases are:
- (done) Test case ktable.historical.uses.cached.key.then.zero.offset
	⁃	client1 subscribes with key1 at offset 1, server fetch returns matching message 1
	⁃	client2 subscribes with key1 at offset 0, server historical fetch should be done from 1
	⁃	client3 subscribes with key2 at offset 0, server historical fetch should be done from 0
- (done) Test case ktable.historical.uses.cached.key.then.latest.offset
	⁃	client1 subscribes with key1 at offset 0, server fetch returns non-matching message 0 and matching message 1
	⁃	client2 subscribes with key1 at offset 0, server historical fetch should be done from 1
	⁃	client3 subscribes with key2 at offset 0, server (live) fetch should be done from 2, only message 3 matches
- (done) Test case fetch.key.historical.does.not.use.cached.key (non-compacted topic)
	⁃	client1 subscribes with key1 at offset 0, server fetch returns non-matching message 0 and matching message 1
	⁃	client2 subscribes with key1 at offset 0, server historical fetch should be done from 0
- (done) Test case ktable.historical.uses.cached.key.then.live
	⁃	client1 subscribes with key1 at offset 0, server fetch returns non-matching message 0 and matching message 1 and non matching message 2
	⁃	next live fetch request is done at offset 3, hold back the response
	⁃	client2 subscribes with key1 at offset 0, server historical fetch should be done from 1, returns messages 1 and 2
	⁃	live fetch responds with matching message 3, both consumes receive