### PR TITLE
CompactedPartitionIndex leak, get tombstone expiry time from Kakfa

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.historical.uses.cached.key.then.live/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.historical.uses.cached.key.then.live/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.historical.uses.cached.key.then.live/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.historical.uses.cached.key.then.live/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.uses.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.uses.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.uses.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.bootstrap.uses.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.compacted.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.compacted.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.compacted.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.compacted.messages/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.deleted.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.deleted.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.deleted.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.delivers.deleted.messages/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.removed.in.subsequent.response/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.removed.in.subsequent.response/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config  value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.removed.in.subsequent.response/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.removed.in.subsequent.response/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.then.updated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.then.updated/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.then.updated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.matches.then.updated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.repeated.tombstone/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.repeated.tombstone/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.repeated.tombstone/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.header.repeated.tombstone/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,11 +82,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch connection

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.after.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.after.unsubscribe/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.after.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.after.unsubscribe/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset.no.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset.no.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset.no.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset.no.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.latest.offset/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.null.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.null.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.null.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.null.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client.rpt
@@ -147,7 +147,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 62        # Size int32
+write 41        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -141,7 +147,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 41        # Size int32
+write 62        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -127,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 41         # Size int32
+read 62         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server.rpt
@@ -133,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 62         # Size int32
+read 41         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.no.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.no.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.no.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live.no.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.live/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.zero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.zero.offset/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.zero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.historical.uses.cached.key.then.zero.offset/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.delayed.describe.response/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.delayed.describe.response/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.delayed.describe.response/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.delayed.describe.response/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,14 +70,15 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 read notify DESCRIBE_REQUEST_RECEIVED
 
 write await DELIVER_DESCRIBE_RESPONSE
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -85,11 +86,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.networks/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.networks/client.rpt
@@ -27,7 +27,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect1}
   option nukleus:route ${newNetworkRouteRef1}
@@ -73,7 +73,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED_ONE
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,10 +81,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -92,11 +93,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream
@@ -167,7 +173,7 @@ read ${kafka:varint(0)}
 
 ## Second network
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect2}
   option nukleus:route ${newNetworkRouteRef2}
@@ -211,7 +217,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED_TWO
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -219,10 +225,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -230,11 +237,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.networks/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.networks/server.rpt
@@ -29,7 +29,7 @@ accept ${networkAccept1}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -64,7 +64,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -72,10 +72,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -83,11 +84,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch stream
@@ -157,7 +163,7 @@ accept ${networkAccept2}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -192,7 +198,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -200,10 +206,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -211,11 +218,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 5s "test1"            # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 56         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 5s "test1" # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -135,8 +141,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 5s "test2"            # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 56         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -146,9 +153,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 5s "test2" # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -193,8 +205,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 5s "test3"            # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 56         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -204,9 +217,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 5s "test3" # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/client.rpt
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 42        # Size int32
+write 63        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 56         # Size int32
+read 90         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -133,7 +133,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 42        # Size int32
+write 63        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -145,7 +145,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 56         # Size int32
+read 90         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -197,7 +197,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 42        # Size int32
+write 63        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -209,7 +209,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 56         # Size int32
+read 90         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -72,8 +72,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 5s "test1" # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 56        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -83,9 +84,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 5s "test1"            # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -131,8 +137,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 5s "test2" # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 56        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -142,9 +149,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 5s "test2"            # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -192,8 +204,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 5s "test3" # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 56        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -203,9 +216,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 5s "test3"            # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message.multiple.topics/server.rpt
@@ -64,7 +64,7 @@ write 1         # topic array length
     write 0     # offline replicas array (empty)
 
 # describe configs request test1
-read 42         # Size int32
+read 63         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -76,7 +76,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 56        # Size int32
+write 90        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -129,7 +129,7 @@ write 1         # topic array length
     write 0     # offline replicas array (empty)
 
 # describe configs request test2
-read 42         # Size int32
+read 63         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -141,7 +141,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 56        # Size int32
+write 90        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -196,7 +196,7 @@ write 1         # topic array length
     write 0     # offline replicas array (empty)
 
 # describe configs request test3
-read 42         # Size int32
+read 63         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -208,7 +208,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 56        # Size int32
+write 90        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.message/server.rpt
@@ -28,7 +28,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -63,7 +63,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -71,10 +71,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -82,11 +83,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes.repeated/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,10 +75,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config  value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes.repeated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,10 +75,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config  value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.first.exceeds.256.bytes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header.multiple.values/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header.multiple.values/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header.multiple.values/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header.multiple.values/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,11 +82,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch connection

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.header/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,11 +82,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch connection

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.headers/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.headers/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,11 +89,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 
 # Fetch stream

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.headers/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.headers/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,11 +82,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch connection

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.live/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.live/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.live/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.live/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -79,7 +79,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -87,10 +87,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -98,11 +99,16 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"            # config value
 read [0x00]     # read_only boolean
 read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
 read notify METADATA_RECEIVED
 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -74,7 +74,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -82,10 +82,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -93,11 +94,16 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"           # config  value
 write [0x00]    # read_only boolean
 write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
 
 # Fetch stream 1

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.tombstone.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.tombstone.repeated/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.tombstone.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.tombstone.repeated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
@@ -1,0 +1,221 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata stream
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 41        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 1         # config names count
+write 14s "cleanup.policy"  # config name
+
+read 55         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 1          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Fetch stream
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+# First fetch
+write 65        # size
+write 1s        # ApiKey Fetch
+write 5s        # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0L        # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 132
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 999L       # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions
+read 72         # length of record batch
+read 10L        # first offset
+read 60         # length     
+read 0x00
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)       # first timestamp
+read ${timestamp}           # maximum timestamp
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(10)}    # record length
+read [0x00]     # attributes
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}     # key length
+read "key0"
+read ${kafka:varint(-1)}    # value length
+read ${kafka:varint(0)}
+
+# second fetch
+write 65        # size
+write 1s        # ApiKey Fetch
+write 5s        # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 11L       # offset
+write -1L
+write ${maximumBytesTest0}
+
+write notify DELIVER_SECOND_FETCH_RESPONSE
+
+read 144
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 999L       # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions
+read 84         # length of record batch
+read 11L        # first offset
+read 72         # length     
+read 0x00
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 0          # last offset delta
+read (long:timestamp)       # first timestamp
+read ${timestamp}           # maximum timestamp
+read -1L
+read -1s
+read -1
+read 1          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]     # attributes
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}    # key length
+read "key1"
+read ${kafka:varint(12)}   # value length
+read "Hello, world"
+read ${kafka:varint(0)}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/client.rpt
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,10 +77,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 84         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 3s "500"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
@@ -17,7 +17,6 @@
 property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
 
 property newTimestamp ${kafka:timestamp()}
-property tombstoneTimestamp ${kafka:timestamp() - (25 * 3600 * 1000)}
 
 property networkAccept "nukleus://kafka/streams/source"
 property networkAcceptWindow 8192
@@ -133,8 +132,8 @@ write [0x02]
 write 0x4e8723aa
 write 0s
 write 0         # last offset Delta
-write ${tombstoneTimestamp}       # first timestamp
-write ${tombstoneTimestamp}       # maximum timestamp
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
 write -1L
 write -1s
 write -1

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
@@ -1,0 +1,210 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+property tombstoneTimestamp ${kafka:timestamp() - (25 * 3600 * 1000)}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata stream
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 41         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 1          # config_names count
+read 14s "cleanup.policy"
+
+write 55        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 1         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Fetch stream
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+# First fetch
+read 65
+read 1s
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 0x04s "test"
+read 1
+read 0
+read 0L
+read -1L
+read [0..4]
+
+write 132
+write ${requestId}
+write 0
+write 1
+write 0x04s "test"
+write 1
+write 0         # Partition
+write 0s
+write 999L      # high watermark
+write -1L
+write 0L        # log start offset
+write -1        # aborted transactions
+write 72        # length of record batch
+write 10L       # first offset
+write 60        # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0         # last offset Delta
+write ${tombstoneTimestamp}       # first timestamp
+write ${tombstoneTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1
+write 1         # number of records
+
+write ${kafka:varint(10)}   # record length
+write [0x00]    # attributes
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key0"
+write ${kafka:varint(-1)}   # value length
+write ${kafka:varint(0)}
+
+# second fetch
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 11L        # offset
+read -1L
+read [0..4]
+
+read notify RECEIVED_SECOND_FETCH_REQUEST
+
+write await DELIVER_SECOND_FETCH_RESPONSE
+
+write 144
+write ${requestId}
+write 0
+write 1
+write 0x04s "test"
+write 1
+write 0          # Partition
+write 0s
+write 999L       # high watermark
+write -1L
+write 0L         # log start offset
+write -1         # aborted transactions
+write 84         # length of record batch
+write 11L        # first offset
+write 72         # length
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 0          # last offset Delta
+write ${newTimestamp}        # first timestamp
+write ${newTimestamp}        # maximum timestamp
+write -1L
+write -1s
+write -1
+write 1          # number of records
+
+write ${kafka:varint(22)}    # record length
+write [0x00]     # attributes
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(4)}     # key length
+write "key1"
+write ${kafka:varint(12)}    # value length
+write "Hello, world"
+write ${kafka:varint(0)}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message/server.rpt
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,10 +70,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 84        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 3s "500"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/client.rpt
@@ -29,7 +29,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -73,7 +73,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,8 +81,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -92,9 +93,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/client.rpt
@@ -85,7 +85,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offset.messagesets.fanout/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/client.rpt
@@ -29,7 +29,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -73,7 +73,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,8 +81,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -92,9 +93,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/client.rpt
@@ -85,7 +85,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/distinct.offsets.message.fanout/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/client.rpt
@@ -27,7 +27,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -71,7 +71,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -79,8 +79,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -90,9 +91,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/client.rpt
@@ -83,7 +83,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/server.rpt
@@ -76,7 +76,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.message/server.rpt
@@ -29,7 +29,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -64,7 +64,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -72,8 +72,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -83,9 +84,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/client.rpt
@@ -27,7 +27,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -71,7 +71,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -79,8 +79,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -90,9 +91,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/client.rpt
@@ -83,7 +83,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/server.rpt
@@ -75,7 +75,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.historical.messages/server.rpt
@@ -28,7 +28,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -63,7 +63,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -71,8 +71,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -82,9 +83,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/client.rpt
@@ -27,7 +27,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -71,7 +71,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -79,8 +79,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -90,9 +91,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/client.rpt
@@ -83,7 +83,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/server.rpt
@@ -76,7 +76,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fanout.with.slow.consumer/server.rpt
@@ -29,7 +29,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -64,7 +64,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -72,8 +72,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -83,9 +84,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/client.rpt
@@ -88,7 +88,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -76,7 +76,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -84,8 +84,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -95,9 +96,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -69,7 +69,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -77,8 +77,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -88,9 +89,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.hash.code.picks.partition.zero/server.rpt
@@ -81,7 +81,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -79,7 +79,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -87,8 +87,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -98,9 +99,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/client.rpt
@@ -91,7 +91,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -74,7 +74,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -82,8 +82,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -93,9 +94,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions.unsubscribe/server.rpt
@@ -86,7 +86,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -79,7 +79,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -87,8 +87,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -98,9 +99,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/client.rpt
@@ -91,7 +91,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -74,7 +74,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -82,8 +82,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -93,9 +94,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.and.no.key.multiple.partitions/server.rpt
@@ -86,7 +86,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/client.rpt
@@ -87,7 +87,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -75,7 +75,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -83,8 +83,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -94,9 +95,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -69,7 +69,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -77,8 +77,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -88,9 +89,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.default.partitioner.picks.partition.one/server.rpt
@@ -81,7 +81,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.historical.does.not.use.cached.key/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.matches.flow.controlled/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.multiple.record.batches.no.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.no.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,8 +76,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -140,7 +146,7 @@ read 15L        # log start offset
 read -1         # aborted transaction count
 
 # list offsets request
-write 41        # Size int32
+write 62        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/client.rpt
@@ -80,7 +80,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -146,7 +146,7 @@ read 15L        # log start offset
 read -1         # aborted transaction count
 
 # list offsets request
-write 62        # Size int32
+write 41        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -133,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # length of record batch
 
 # list offsets request
-read 62         # Size int32
+read 41         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.nonzero.offset.too.early.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -127,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # length of record batch
 
 # list offsets request
-read 41         # Size int32
+read 62         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.three.matches.flow.controlled/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.last.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/fetch.key.zero.offset.multiple.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.and.fetch.key.zero.offset.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.first.message.has.empty.header.value/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.last.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.multiple.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/header.zero.offset.repeated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.and.fetch.key.zero.offset.first.matches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/headers.zero.offset.multiple.matches.historical/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/client.rpt
@@ -80,7 +80,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,8 +76,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/server.rpt
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.abort.and.reconnect/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/client.rpt
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/server.rpt
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/live.fetch.reset.reconnect.and.message/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,8 +75,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/client.rpt
@@ -79,7 +79,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/message.size.exceeds.max.partition.bytes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset.messages/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/server.rpt
@@ -25,7 +25,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -60,7 +60,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -68,8 +68,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -79,9 +80,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/nonzero.offset/server.rpt
@@ -72,7 +72,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/client.rpt
@@ -80,7 +80,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -147,7 +147,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 62        # Size int32
+write 41        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,8 +76,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -141,7 +147,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 41        # Size int32
+write 62        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${describeConfigsRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -133,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 62         # Size int32
+read 41         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:describeConfigsRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${describeConfigsRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -127,7 +133,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 41         # Size int32
+read 62         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -79,7 +79,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -87,8 +87,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -98,9 +99,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -154,7 +160,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 41        # Size int32
+write 62        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 
@@ -279,7 +285,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 41        # Size int32
+write 62        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/client.rpt
@@ -91,7 +91,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -160,7 +160,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 62        # Size int32
+write 41        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 
@@ -285,7 +285,7 @@ read -1         # aborted transaction count
 read 0          # record set size
 
 # list offsets request
-write 62        # Size int32
+write 41        # Size int32
 write 2s        # ApiKey (ListOffsets)
 write 2s        # ApiVersion 
 write ${newMetadataRequestId} # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -74,7 +74,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -82,8 +82,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -93,9 +94,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -139,7 +145,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 41         # Size int32
+read 62         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 
@@ -256,7 +262,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 41         # Size int32
+read 62         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.nodes/server.rpt
@@ -86,7 +86,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -145,7 +145,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 62         # Size int32
+read 41         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 
@@ -262,7 +262,7 @@ write -1        # aborted transaction count
 write 0         # record set size
 
 # list offsets request
-read 62         # Size int32
+read 41         # Size int32
 read 2s         # ApiKey (ListOffsets)
 read 2s         # ApiVersion 
 read (int:listOffsetsRequestId) # CorrelationId 

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/client.rpt
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 42        # Size int32
+write 63        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -133,7 +133,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 42        # Size int32
+write 63        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -76,10 +76,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 5s "test1" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 5s "test1"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean
@@ -135,10 +141,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 5s "test2" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 55         # Size int32
+read 89         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -146,9 +153,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 5s "test2"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/server.rpt
@@ -64,7 +64,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 42         # Size int32
+read 63         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:describeConfigsRequestId) # CorrelationId int32
@@ -128,7 +128,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 42         # Size int32
+read 63         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:describeConfigsRequestId) # CorrelationId int32

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/offset.too.early.multiple.topics/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -72,10 +72,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 5s "test1"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 55        # Size int32
+write 89        # Size int32
 write ${describeConfigsRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -83,9 +84,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 5s "test1" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean
@@ -130,12 +136,13 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 5s "test2"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write await WRITE_SECOND_DESCRIBE_CONFIGS_RESPONSE 
 
-write 55        # Size int32
+write 89        # Size int32
 write ${describeConfigsRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -143,9 +150,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 5s "test2" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.deleted.record/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.ends.with.truncated.record/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated.at.record.boundary/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/record.batch.truncated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.length.record.batch/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,8 +75,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/client.rpt
@@ -79,7 +79,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.first.record.batch.large.requires.3.fetches/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -73,7 +73,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,8 +81,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -92,9 +93,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/client.rpt
@@ -85,7 +85,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/server.rpt
@@ -79,7 +79,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message.single.partition.multiple.nodes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -67,7 +67,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -75,8 +75,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -86,9 +87,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.message/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.fanout/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,8 +75,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/client.rpt
@@ -79,7 +79,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes.repeated/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/client.rpt
@@ -23,7 +23,7 @@ property newMetadataRequestId ${kafka:newRequestId()}
 property newRequestId ${kafka:newRequestId()}
 property maximumWaitTime 500
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -67,7 +67,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -75,8 +75,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -86,9 +87,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/client.rpt
@@ -79,7 +79,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.first.exceeds.256.bytes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget.reset/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.group.budget/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -79,7 +79,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -87,8 +87,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -98,9 +99,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/client.rpt
@@ -91,7 +91,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -74,7 +74,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -82,8 +82,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -93,9 +94,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.nodes/server.rpt
@@ -86,7 +86,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -74,7 +74,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -82,8 +82,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -93,9 +94,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/client.rpt
@@ -86,7 +86,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -69,7 +69,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -77,8 +77,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -88,9 +89,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions.partition.1/server.rpt
@@ -81,7 +81,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -74,7 +74,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -82,8 +82,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -93,9 +94,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/client.rpt
@@ -86,7 +86,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -69,7 +69,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -77,8 +77,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -88,9 +89,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages.multiple.partitions/server.rpt
@@ -81,7 +81,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/client.rpt
@@ -81,7 +81,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -69,7 +69,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -77,8 +77,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -88,9 +89,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/server.rpt
@@ -74,7 +74,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messages/server.rpt
@@ -27,7 +27,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -62,7 +62,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -70,8 +70,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -81,9 +82,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/client.rpt
@@ -82,7 +82,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -70,7 +70,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -78,8 +78,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -89,9 +90,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/server.rpt
@@ -75,7 +75,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets.fanout/server.rpt
@@ -28,7 +28,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -63,7 +63,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -71,8 +71,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -82,9 +83,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/client.rpt
@@ -82,7 +82,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/client.rpt
@@ -26,7 +26,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -70,7 +70,7 @@ read 1          # topic array length
     read 0      # offline replicas array (empty)
 read notify METADATA_RECEIVED
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -78,8 +78,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -89,9 +90,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/server.rpt
@@ -75,7 +75,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.messagesets/server.rpt
@@ -28,7 +28,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -63,7 +63,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -71,8 +71,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -82,9 +83,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/client.rpt
@@ -80,7 +80,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,8 +76,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/server.rpt
@@ -25,7 +25,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -60,7 +60,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -68,8 +68,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -79,9 +80,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset.no.messages/server.rpt
@@ -72,7 +72,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/client.rpt
@@ -80,7 +80,7 @@ write 2         # config names count
 write 14s "cleanup.policy"  # config name
 write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/client.rpt
@@ -25,7 +25,7 @@ property maximumWaitTime 500
 property maximumBytes 65535
 property maximumBytesTest0 8192
 
-# Metadata stream
+# Metadata connection
 connect await ROUTED_SERVER
         ${networkConnect}
   option nukleus:route ${newNetworkRouteRef}
@@ -68,7 +68,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,8 +76,9 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
 read 54         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/server.rpt
@@ -25,7 +25,7 @@ accept ${networkAccept}
   option nukleus:transmission "duplex"
   option nukleus:byteorder "network"
 
-# Metadata stream
+# Metadata connection
 accepted
 connected
 
@@ -60,7 +60,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -68,8 +68,9 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
 write 54        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
@@ -79,9 +80,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/zero.offset/server.rpt
@@ -72,7 +72,7 @@ read 2          # config_names count
 read 14s "cleanup.policy"
 read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/broker.connection.reset.and.retry/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/broker.connection.reset.and.retry/client.rpt
@@ -88,7 +88,7 @@ read 1 # topic array length
     read -1 # isr array (null)
     read 0 # offline replicas array (empty)
     
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -96,10 +96,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size (describeConfigs response)
+read 88         # Size (describeConfigs response)
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -107,9 +108,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/broker.connection.reset.and.retry/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/broker.connection.reset.and.retry/server.rpt
@@ -71,7 +71,7 @@ write 1 # topic array length
     write -1 # isr array (null)
     write 0 # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:describeRequestId) # CorrelationId int32
@@ -79,10 +79,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${describeRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -90,9 +91,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.leader.not.available.and.retry/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.leader.not.available.and.retry/client.rpt
@@ -122,7 +122,7 @@ read 1 # topic array length
     read -1 # isr array (null)
     read 0 # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newDescribeRequestId} # CorrelationId int32
@@ -130,10 +130,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newDescribeRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -141,9 +142,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.leader.not.available.and.retry/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.leader.not.available.and.retry/server.rpt
@@ -118,7 +118,7 @@ write 1 # topic array length
     write -1 # isr array (null)
     write 0 # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:describeRequestId) # CorrelationId int32
@@ -126,10 +126,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${describeRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -137,9 +138,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes.and.replicas/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes.and.replicas/client.rpt
@@ -77,7 +77,7 @@ read 1          # topic array length
     read -1     # isr array (null)
     read 0      # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -85,10 +85,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -96,9 +97,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes.and.replicas/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes.and.replicas/server.rpt
@@ -75,7 +75,7 @@ write 1         # topic array length
     write -1    # isr array (null)
     write 0     # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -83,10 +83,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -94,9 +95,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes/client.rpt
@@ -73,7 +73,7 @@ read 1 # topic array length
     read -1 # isr array (null)
     read 0 # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -81,10 +81,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -92,9 +93,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.nodes/server.rpt
@@ -71,7 +71,7 @@ write 1 # topic array length
     write -1 # isr array (null)
     write 0 # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -79,10 +79,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -90,9 +91,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.partitions/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.partitions/client.rpt
@@ -68,7 +68,7 @@ read 1 # topic array length
     read -1 # isr array (null)
     read 0 # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -76,10 +76,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -87,9 +88,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.partitions/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.multiple.partitions/server.rpt
@@ -66,7 +66,7 @@ write 1 # topic array length
     write -1 # isr array (null)
     write 0 # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -74,10 +74,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -85,9 +86,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.single.partition/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.single.partition/client.rpt
@@ -61,7 +61,7 @@ read 1 # topic array length
     read -1 # isr array (null)
     read 0 # offline replicas array (empty)
 
-write 41        # Size int32
+write 62        # Size int32
 write 32s       # ApiKey int16 (DescribeConfigs)
 write 0s        # ApiVersion int16
 write ${newMetadataRequestId} # CorrelationId int32
@@ -69,10 +69,11 @@ write -1s       # ClientId string (null)
 write 1         # resources count
 write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
 write 4s "test" # topic name
-write 1         # config names count
+write 2         # config names count
 write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
 
-read 54         # Size int32
+read 88         # Size int32
 read ${newMetadataRequestId} # CorrelationId int32
 read [0..4]     # throttle_time_ms int32
 read 1          # resources count
@@ -80,9 +81,14 @@ read 0s         # error code
 read -1s        # error message
 read [0x02]     # resource type (topic)
 read 4s "test"  # topic name
-read 1          # config entries count
+read 2          # config entries count
 read 14s "cleanup.policy"   # config name
 read 6s "delete"            # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
 read [0x00]     # read_only boolean
 read [0x01]     # is_default boolean
 read [0x00]     # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.single.partition/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/metadata.v5/one.topic.single.partition/server.rpt
@@ -59,7 +59,7 @@ write 1 # topic array length
     write -1 # isr array (null)
     write 0 # offline replicas array (empty)
 
-read 41         # Size int32
+read 62         # Size int32
 read 32s        # ApiKey int16 (DescribeConfigs)
 read 0s         # ApiVersion int16
 read (int:metadataRequestId) # CorrelationId int32
@@ -67,10 +67,11 @@ read -1s        # ClientId string (null)
 read 1          # [Resources] array length
 read [0x02]     # resource type int8 (topic) 
 read 4s "test"  # topic name
-read 1          # config_names count
+read 2          # config_names count
 read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
 
-write 54        # Size int32
+write 88        # Size int32
 write ${metadataRequestId}  # CorrelationId int32
 write 0         # throttle_time_ms int32
 write 1         # resources count
@@ -78,9 +79,14 @@ write 0s        # error code
 write -1s       # error message
 write [0x02]    # resource type
 write 4s "test" # topic name
-write 1         # config entries count
+write 2         # config entries count
 write 14s "cleanup.policy"  # config name
 write 6s "delete"           # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
 write [0x00]    # read_only boolean
 write [0x01]    # is_default boolean
 write [0x00]    # is_sensitive boolean

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.message/client.rpt
@@ -20,6 +20,7 @@ property applicationConnect "nukleus://kafka/streams/source"
 property applicationConnectWindow 8192
 
 property offset 0
+property messageOffset ${offset + 1}
 
 connect await CONNECT_CLIENT
         ${applicationConnect}
@@ -43,6 +44,6 @@ read nukleus:begin.ext 0
 
 read notify CLIENT_CONNECTED
 
-read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(offset + 1)}
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(messageOffset)}
 read nukleus:data.ext 4 "key1"
 read "Hello, world"

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -264,6 +264,17 @@ public class FetchIT
 
     @Test
     @Specification(
+    {"${scripts}/compacted.tombstone.then.message/client",
+     "${scripts}/compacted.tombstone.then.message/server"})
+    public void shouldReceiveTombstoneAndMessageFromCompactedTopic() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification(
     {"${scripts}/compacted.messages.first.exceeds.256.bytes/client",
      "${scripts}/compacted.messages.first.exceeds.256.bytes/server"})
     public void shouldReceiveLargeCompactedMessageFilteredByKey() throws Exception

--- a/tools/align_comments.sed
+++ b/tools/align_comments.sed
@@ -9,7 +9,7 @@
 #
 # Usage
 # =====
-# ufind src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ -name "*.rpt"| xargs -L 1 sed -i "~" -f tools/align_comments.sed
+# find src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/ -name "*.rpt"| xargs -L 1 sed -i "" -f tools/align_comments.sed
 #
 
 /^[^#]\{4\}[^#]* * #/s/  *#/ #/


### PR DESCRIPTION
Altered all kafka scripts to read configuration parameter "delete.retention.ms" in the DescribeConfigs call. Added a test for to tombstone expiry: src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.tombstone.then.message