### PR TITLE
Added new test for stuck flow case

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes.historical/client.rpt
@@ -1,0 +1,441 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId1 ${kafka:newRequestId()}
+property newRequestId2 ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata connection
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 126        # Size
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 2          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null) 
+
+  read 2
+  read 7s "broker2"
+  read 9093
+  read -1s
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 2        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+
+    read 0s     # error code
+    read 1      # partition
+    read 2      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+
+write 62        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 2         # config names count
+write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
+
+read 89         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 2          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"            # config value
+read [0x00]     # read_only boolean
+read [0x00]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+read notify METADATA_WRITTEN
+
+# Live fetch connection partition 0
+connect await METADATA_WRITTEN
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify LIVE_ZERO_CONNECTED
+
+write 65
+write 1s        # Fetch
+write 5s        # version
+write ${newRequestId1}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 423
+read ${newRequestId1}
+read [0..4]
+read 0x01
+read 0x04s "test"
+read 1
+read 0
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1
+read 363        # length of record set
+read 0L         # first offset
+read 351        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}     # key length
+read "key1"
+read ${kafka:varint(12)}
+read "Hello, world"
+read ${kafka:varint(0)}
+
+read ${kafka:varint(277)}
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key2"
+read ${kafka:varint(266)}   # value length
+read [0..266]               # value
+read [0x00]     # headers
+
+# Next fetch request
+write 65
+
+# Live fetch connection partition 1
+connect await LIVE_ZERO_CONNECTED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+
+connected
+
+read notify LIVE_ONE_CONNECTED
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId1}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 1         # Partition
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 423
+read ${newRequestId1}
+read [0..4]
+read 0x01
+read 0x04s "test"
+read 1
+read 1          # partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1
+read 363        # length of record set
+read 0L         # first offset
+read 351        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}     # key length
+read "key3"
+read ${kafka:varint(12)}
+read "Hello, again"
+read ${kafka:varint(0)}
+
+read ${kafka:varint(277)}
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key4"
+read ${kafka:varint(266)}   # value length
+read [0..266]               # value
+read [0x00]     # headers
+
+# Next fetch request
+write 65
+
+
+# Historical fetch connection partition 0
+connect await LIVE_ONE_CONNECTED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+read notify HISTORICAL_ZERO_CONNECTED
+
+write 65
+write 1s        # Fetch
+write 5s        # version
+write ${newRequestId1}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 423
+read ${newRequestId1}
+read [0..4]
+read 0x01
+read 0x04s "test"
+read 1
+read 0          # partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1
+read 363        # length of record set
+read 0L         # first offset
+read 351        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}     # key length
+read "key1"
+read ${kafka:varint(12)}
+read "Hello, world"
+read ${kafka:varint(0)}
+
+read ${kafka:varint(277)}
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key2"
+read ${kafka:varint(266)}   # value length
+read [0..266]               # value
+read [0x00]     # headers
+
+# Next fetch request
+write 65
+
+# Historical fetch connection partition 1
+connect await HISTORICAL_ZERO_CONNECTED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId1}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 1         # Partition
+write 0L
+write -1L
+write ${maximumBytesTest0}
+
+read 423
+read ${newRequestId1}
+read [0..4]
+read 0x01
+read 0x04s "test"
+read 1
+read 1          # partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1
+read 363        # length of record set
+read 0L         # first offset
+read 351        # length of record batch
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 1          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 2          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(0)}
+read ${kafka:varint(0)}
+read ${kafka:varint(4)}     # key length
+read "key3"
+read ${kafka:varint(12)}
+read "Hello, again"
+read ${kafka:varint(0)}
+
+read ${kafka:varint(277)}
+read [0x00]
+read ${kafka:varint(0)}     # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key4"
+read ${kafka:varint(266)}   # value length
+read [0..266]               # value
+read [0x00]     # headers
+
+# Next fetch request
+write 65

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.multiple.nodes.historical/server.rpt
@@ -1,0 +1,400 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata connection
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 126       # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 2         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+
+  write 2
+  write 7s "broker2"
+  write 9093
+  write -1s
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 2       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+    write 0s    # error code
+    write 1     # partition
+    write 2     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 62         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 2          # config_names count
+read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
+
+write 89        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 2         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"           # config  value
+write [0x00]    # read_only boolean
+write [0x00]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Live fetch connection partition 0
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # size
+read 1s         # ApiKey Fetch
+read 5s         # version
+read (int:requestId1)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0
+read 0L
+read -1L
+read [0..4]
+
+write 423
+write ${requestId1}
+write 0
+write 1
+write 4s "test"
+write 1         # number of partition responses
+write 0         # partition
+write 0s
+write 3L        # high watermark
+write -1L
+write 0L
+write -1
+write 363       # physical length of record set
+write 0L        # first offset
+write 351       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 2         # number of records
+
+write ${kafka:varint(22)}    # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(4)}     # key length
+write "key1"
+write ${kafka:varint(12)}
+write "Hello, world"
+write ${kafka:varint(0)}
+
+write ${kafka:varint(277)}  # Record length
+write [0x00]
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key2"
+write ${kafka:varint(266)}  # value length
+write ${kafka:randomBytes(266)}
+write ${kafka:varint(0)}    # headers (none)
+
+# Next fetch request
+read 65
+
+read notify BOOTSTRAP_COMPLETE_PARTITION_ZERO
+
+# Live fetch connection partition 1
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+connected
+
+read 65
+read 0x01s
+read 0x05s
+read (int:requestId2)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 0x04s "test"
+read 1
+read 1          # partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 423
+write ${requestId2}
+write 0
+write 1
+write 4s "test"
+write 1         # number of partition responses
+write 1         # partition
+write 0s
+write 3L        # high watermark
+write -1L
+write 0L
+write -1
+write 363       # physical length of record set
+write 0L        # first offset
+write 351       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 2         # number of records
+
+write ${kafka:varint(22)}    # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(4)}     # key length
+write "key3"
+write ${kafka:varint(12)}
+write "Hello, again"
+write ${kafka:varint(0)}
+
+write ${kafka:varint(277)}  # Record length
+write [0x00]
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key4"
+write ${kafka:varint(266)}  # value length
+write ${kafka:randomBytes(266)}
+write ${kafka:varint(0)}    # headers (none)
+
+# Next fetch request
+read 65
+
+read notify BOOTSTRAP_COMPLETE_PARTITION_ONE
+
+# Historical fetch connection partition 0
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # size
+read 1s         # ApiKey Fetch
+read 5s         # version
+read (int:requestId1)
+read -1s
+read -1
+read [0..4]
+read 1
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0
+read 0L
+read -1L
+read [0..4]
+
+write 423
+write ${requestId1}
+write 0
+write 1
+write 4s "test"
+write 1         # number of partition responses
+write 0         # partition
+write 0s
+write 3L        # high watermark
+write -1L
+write 0L
+write -1
+write 363       # physical length of record set
+write 0L        # first offset
+write 351       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 2         # number of records
+
+write ${kafka:varint(22)}    # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(4)}     # key length
+write "key1"
+write ${kafka:varint(12)}
+write "Hello, world"
+write ${kafka:varint(0)}
+
+write ${kafka:varint(277)}  # Record length
+write [0x00]
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key2"
+write ${kafka:varint(266)}  # value length
+write ${kafka:randomBytes(266)}
+write ${kafka:varint(0)}    # headers (none)
+
+# Historical fetch connection partition 1
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker2", 9093)}
+connected
+
+read 65
+read 0x01s
+read 0x05s
+read (int:requestId2)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 1          # partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write await WRITE_HISTORICAL_PARTITION_ONE_RESPONSE
+
+write 423
+write ${requestId2}
+write 0
+write 1
+write 4s "test"
+write 1         # number of partition responses
+write 1         # partition
+write 0s
+write 3L        # high watermark
+write -1L
+write 0L
+write -1
+write 363       # physical length of record set
+write 0L        # first offset
+write 351       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 1         # last offset delta
+write ${newTimestamp}
+write ${newTimestamp}
+write -1L
+write -1s
+write -1
+write 2         # number of records
+
+write ${kafka:varint(22)}    # record length
+write [0x00]
+write ${kafka:varint(0)}
+write ${kafka:varint(0)}
+write ${kafka:varint(4)}     # key length
+write "key3"
+write ${kafka:varint(12)}
+write "Hello, again"
+write ${kafka:varint(0)}
+
+write ${kafka:varint(277)}  # Record length
+write [0x00]
+write ${kafka:varint(0)}    # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key4"
+write ${kafka:varint(266)}  # value length
+write ${kafka:randomBytes(266)}
+write ${kafka:varint(0)}    # headers (none)

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.multiple.nodes.historical/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.multiple.nodes.historical/client.rpt
@@ -1,0 +1,89 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow1 8192
+property applicationConnectWindow2 8192
+
+connect await CONNECT_CLIENT_ONE
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow1}
+    option nukleus:update "none"
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 2 ${kafka:varint(1)} ${kafka:varint(0)}
+read nukleus:data.ext 4 "key1"
+read "Hello, world"
+
+read nukleus:data.ext ${timestamp} 2 ${kafka:varint(2)} ${kafka:varint(0)}
+read nukleus:data.ext 4 "key2"
+read [0..1]
+read notify CLIENT_ONE_DATA_RECEIVED
+
+# Rest of messages are not received because of the connect option nukleus:update "none"
+
+connect await CONNECT_CLIENT_TWO
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow2}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read nukleus:data.ext (long:timestamp) 2 ${kafka:varint(1)} ${kafka:varint(0)}
+read nukleus:data.ext 4 "key1"
+read "Hello, world"
+
+read nukleus:data.ext ${timestamp} 2 ${kafka:varint(2)} ${kafka:varint(0)}
+read nukleus:data.ext 4 "key2"
+read [0..266]
+
+read nukleus:data.ext ${timestamp} 2 ${kafka:varint(2)} ${kafka:varint(1)}
+read nukleus:data.ext 4 "key3"
+read "Hello, again"
+
+read nukleus:data.ext ${timestamp} 2 ${kafka:varint(2)} ${kafka:varint(2)}
+read nukleus:data.ext 4 "key4"
+read [0..266]

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.multiple.nodes.historical/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.multiple.nodes.historical/server.rpt
@@ -1,0 +1,102 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+       
+# Client one
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(1)} ${kafka:varint(0)}
+write nukleus:data.ext 4 "key1"
+write "Hello, world"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(0)}
+write nukleus:data.ext 4 "key2"
+write ${kafka:randomBytes(266)}
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(1)}
+write nukleus:data.ext 4 "key3"
+write "Hello, again"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(2)}
+write nukleus:data.ext 4 "key4"
+write ${kafka:randomBytes(266)}
+write flush
+
+# Client two
+accepted
+
+read nukleus:begin.ext 0x04s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(1)} ${kafka:varint(0)}
+write nukleus:data.ext 4 "key1"
+write "Hello, world"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(0)}
+write nukleus:data.ext 4 "key2"
+write ${kafka:randomBytes(266)}
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(1)}
+write nukleus:data.ext 4 "key3"
+write "Hello, again"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 2 ${kafka:varint(2)} ${kafka:varint(2)}
+write nukleus:data.ext 4 "key4"
+write ${kafka:randomBytes(266)}
+write flush

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -434,6 +434,18 @@ public class FetchIT
 
     @Test
     @Specification(
+    {"${scripts}/compacted.messages.multiple.nodes.historical/client",
+     "${scripts}/compacted.messages.multiple.nodes.historical/server"})
+    public void shouldReceiveCompactedHistoricalMessagesFromMultipleNodes() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.notifyBarrier("WRITE_HISTORICAL_PARTITION_ONE_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification(
     {"${scripts}/compacted.message.multiple.networks/client",
      "${scripts}/compacted.message.multiple.networks/server"})
     public void shouldReceiveCompactedMessagesFromMultipleNetworks() throws Exception

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -402,6 +402,18 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/compacted.messages.multiple.nodes.historical/client",
+        "${scripts}/compacted.messages.multiple.nodes.historical/server"})
+    public void shouldReceiveCompactedHistoricalMessagesFromMultipleNodes() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("CONNECT_CLIENT_ONE");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/compacted.partial.message.aborted/client",
         "${scripts}/compacted.partial.message.aborted/server"})
     public void shouldReceivePartialCompactedMessage() throws Exception


### PR DESCRIPTION
(large message being dispatched from cache on two separate partitions from different historical streams). Test case is:
- Compacted topic test has two partitions on different broker nodes
- Bootstrap is enabled but not proactive caching
- each partition "contains" a small message at offset 0 and a large one at offset 1 
- bootstrap reads all messages
- second live fetch request is received on each connection and does not respond
- client 1 subscribes, with initial window insufficient for the first large message and window updates turned off 
  - client1 receives message (0,0L) and only part of message (0,1L) from partition 0 due to limited window
- client 2 subscribes with a window insufficient for both large messages
 - client2 receives messages (0,0L), (0,1L), (1,0L) and (1,1L) from partition 1 from historical fetch, with the second large message ((1,1L)  being fragmented
