### PR TITLE
Added new tests for slow consumer on live stream

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.slow.consumer/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.slow.consumer/client.rpt
@@ -1,0 +1,207 @@
+#
+# Copyright 2016-2018 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef  ${nuklei:newReferenceId()} # external
+
+property networkConnect "nukleus://kafka/streams/source"
+property networkConnectWindow 8192
+
+property newMetadataRequestId ${kafka:newRequestId()}
+property newRequestId ${kafka:newRequestId()}
+property maximumWaitTime 500
+property maximumBytes 65535
+property maximumBytesTest0 8192
+
+# Metadata connection
+connect await ROUTED_SERVER
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 21        # Size int32
+write 0x03s     # ApiKey int16 (Metadata)
+write 0x05s     # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # [TopicName] array length
+  write 4s "test"
+write [0x00]    # allow_auto_topic_creation (boolean)
+
+read 85         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # brokers array length
+  read 1        # broker id
+  read 7s "broker1"
+  read 9093     # port int32
+  read -1s      # rack string (null)
+read 9s "cluster 1"
+read 1          # controller broker id
+read 1          # topic array length
+  read 0s       # error code
+  read 4s "test"
+  read [0x00]   # is_internal boolean
+  read 1        # partition array length
+    read 0s     # error code
+    read 0      # partition
+    read 1      # leader
+    read 0      # replicas array (empty)
+    read -1     # isr array (null)
+    read 0      # offline replicas array (empty)
+read notify METADATA_RECEIVED
+
+write 62        # Size int32
+write 32s       # ApiKey int16 (DescribeConfigs)
+write 0s        # ApiVersion int16
+write ${newMetadataRequestId} # CorrelationId int32
+write -1s       # ClientId string (null)
+write 1         # resources count
+write [0x02]    # resource type (topic is 2, from org/apache/kafka/common/resource/ResourceType.java)
+write 4s "test" # topic name
+write 2         # config names count
+write 14s "cleanup.policy"  # config name
+write 19s "delete.retention.ms"  # config name
+
+read 89         # Size int32
+read ${newMetadataRequestId} # CorrelationId int32
+read [0..4]     # throttle_time_ms int32
+read 1          # resources count
+read 0s         # error code
+read -1s        # error message
+read [0x02]     # resource type (topic)
+read 4s "test"  # topic name
+read 2          # config entries count
+read 14s "cleanup.policy"   # config name
+read 7s "compact"           # config value
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+read 19s "delete.retention.ms"
+read 8s "86400000"
+read [0x00]     # read_only boolean
+read [0x01]     # is_default boolean
+read [0x00]     # is_sensitive boolean
+
+# Fetch stream
+connect await METADATA_RECEIVED
+        ${networkConnect}
+  option nukleus:route ${newNetworkRouteRef}
+  option nukleus:window ${networkConnectWindow} 
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+write nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+
+connected
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0          # Partition
+write 0L         # offset
+write -1L
+write ${maximumBytesTest0}
+
+read 190        # Size
+read ${newRequestId}
+read [0..4]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0s
+read 3L         # high watermark
+read -1L
+read 0L         # log start offset
+read -1         # aborted transactions (null)
+read 130
+read 0L         # first offset
+read 118        # length
+read 0
+read [0x02]
+read 0x4e8723aa
+read 0s
+read 2          # last offset delta
+read (long:timestamp)
+read ${timestamp}
+read -1L
+read -1s
+read -1
+read 3          # number of records
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(10)}    # timestamp delta
+read ${kafka:varint(0)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key1"
+read ${kafka:varint(12)}
+read "Hello, world"
+read [0x00]
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(20)}    # timestamp delta
+read ${kafka:varint(1)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key2"
+read ${kafka:varint(12)}
+read "Hello second"
+read [0x00]
+
+read ${kafka:varint(22)}    # record length
+read [0x00]
+read ${kafka:varint(30)}    # timestamp delta
+read ${kafka:varint(2)}     # offset delta
+read ${kafka:varint(4)}     # key length
+read "key3"
+read ${kafka:varint(12)}
+read "Hello, third"
+read [0x00]
+
+write 65         # size
+write 1s         # ApiKey Fetch
+write 5s         # version
+write ${newRequestId}
+write -1s
+write -1
+write ${maximumWaitTime}
+write 1
+write ${maximumBytes}
+write [0x00]
+write 1
+write 4s "test"
+write 1
+write 0          # Partition
+write 3L         # offset
+write -1L
+write ${maximumBytesTest0}

--- a/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.slow.consumer/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/kafka/fetch.v5/compacted.messages.slow.consumer/server.rpt
@@ -1,0 +1,195 @@
+#
+# Copyright 2016-2018 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newNetworkRouteRef ${nuklei:newReferenceId()} # external scope
+
+property newTimestamp ${kafka:timestamp()}
+
+property networkAccept "nukleus://kafka/streams/source"
+property networkAcceptWindow 8192
+
+accept ${networkAccept}
+  option nukleus:route  ${newNetworkRouteRef}
+  option nukleus:window ${networkAcceptWindow}
+  option nukleus:transmission "duplex"
+  option nukleus:byteorder "network"
+
+# Metadata connection
+accepted
+connected
+
+read 21         # Size int32
+read 0x03s      # ApiKey int16 (Metadata)
+read 0x05s      # ApiVersion int16
+read (int:metadataRequestId)
+read -1s        # ClientId string (null)
+read 1          # [TopicName] array length
+  read 4s "test"
+read [0x00]     # allow_auto_topic_creation (boolean)
+
+write 85        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # brokers array length
+  write 1       # broker id
+  write 7s "broker1"
+  write 9093    # port int32
+  write -1s     # rack string (null)
+write 9s "cluster 1"
+write 1         # controller broker id
+write 1         # topic array length
+  write 0s      # error code
+  write 4s "test"
+  write byte 0x00           # is_internal
+  write 1       # partition array length
+    write 0s    # error code
+    write 0     # partition
+    write 1     # leader
+    write 0     # replicas array (empty)
+    write -1    # isr array (null)
+    write 0     # offline replicas array (empty)
+
+read 62         # Size int32
+read 32s        # ApiKey int16 (DescribeConfigs)
+read 0s         # ApiVersion int16
+read (int:metadataRequestId) # CorrelationId int32
+read -1s        # ClientId string (null)
+read 1          # [Resources] array length
+read [0x02]     # resource type int8 (topic) 
+read 4s "test"  # topic name
+read 2          # config_names count
+read 14s "cleanup.policy"
+read 19s "delete.retention.ms"
+
+write 89        # Size int32
+write ${metadataRequestId}  # CorrelationId int32
+write 0         # throttle_time_ms int32
+write 1         # resources count
+write 0s        # error code
+write -1s       # error message
+write [0x02]    # resource type
+write 4s "test" # topic name
+write 2         # config entries count
+write 14s "cleanup.policy"  # config name
+write 7s "compact"          # config  value
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+write 19s "delete.retention.ms"
+write 8s "86400000"
+write [0x00]    # read_only boolean
+write [0x01]    # is_default boolean
+write [0x00]    # is_sensitive boolean
+
+# Fetch stream
+accepted
+read nukleus:begin.ext ${tcp:beginExtRemoteHost("broker1", 9093)}
+connected
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 0L         # offset
+read -1L
+read [0..4]
+
+write 190       # Size
+write ${requestId}
+write 0
+write 1
+write 4s "test"
+write 1
+write 0         # Partition
+write 0s        # partition error code
+write 3L        # high_watermark
+write -1L       # last_stable_offset
+write 0L        # log_start_offset
+write -1        # aborted_transactions (null)
+write 130       # length of record set
+write 0L        # first offset
+write 118       # length of record batch
+write 0
+write [0x02]
+write 0x4e8723aa
+write 0s
+write 2         # last offset delta
+write ${newTimestamp}       # first timestamp
+write ${newTimestamp}       # maximum timestamp
+write -1L
+write -1s
+write -1        # first sequence
+write 3         # number of records
+
+write ${kafka:varint(22)}   # Record length
+write [0x00]
+write ${kafka:varint(10)}   # timestamp delta
+write ${kafka:varint(0)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key1"
+write ${kafka:varint(12)}
+write "Hello, world"
+write [0x00]
+
+write ${kafka:varint(22)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(20)}   # timestamp delta
+write ${kafka:varint(1)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key2"
+write ${kafka:varint(12)}   # value length
+write "Hello second"
+write [0x00]
+
+write ${kafka:varint(22)}   # Record length
+write [0x00]    # attributes
+write ${kafka:varint(30)}   # timestamp delta
+write ${kafka:varint(2)}    # offset delta
+write ${kafka:varint(4)}    # key length
+write "key3"
+write ${kafka:varint(12)}   # value length
+write "Hello, third"
+write [0x00]
+
+
+read 65         # Size
+read 1s         # Fetch
+read 5s
+read (int:requestId)
+read -1s
+read -1
+read [0..4]
+read 0x01
+read [0..4]
+read [0x00]
+read 1
+read 4s "test"
+read 1
+read 0          # Partition
+read 3L         # offset
+read -1L
+read [0..4]
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.slow.consumer/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.slow.consumer/client.rpt
@@ -1,0 +1,54 @@
+#
+# Copyright 2016-2018 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+
+property applicationConnect "nukleus://kafka/streams/source"
+property applicationConnectWindow 15
+
+connect await ROUTED_CLIENT
+        ${applicationConnect}
+    option nukleus:route ${newApplicationRouteRef}
+    option nukleus:window ${applicationConnectWindow}
+    option nukleus:transmission "half-duplex"
+
+write nukleus:begin.ext 0x04s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+
+connected
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+read notify CLIENT_CONNECTED
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(1)}
+read nukleus:data.ext 4 "key1"
+read "Hello, world"
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(2)}
+read nukleus:data.ext 4 "key2"
+read "Hello second"
+
+read nukleus:data.ext (long:timestamp) 1 ${kafka:varint(3)}
+read nukleus:data.ext 4 "key3"
+read "Hello, third"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.slow.consumer/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/kafka/streams/fetch/compacted.messages.slow.consumer/server.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2016-2018 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newApplicationRouteRef ${nuklei:newReferenceId()} # external scope
+property newTimestamp ${kafka:timestamp()}
+
+property applicationAccept "nukleus://kafka/streams/source"
+property applicationAcceptWindow 8192
+
+accept ${applicationAccept}
+       option nukleus:route ${newApplicationRouteRef}
+       option nukleus:window ${applicationAcceptWindow}
+       option nukleus:transmission "half-duplex"
+accepted
+
+read nukleus:begin.ext 4s "test"
+read nukleus:begin.ext 1 ${kafka:varint(0)}
+read nukleus:begin.ext -1
+read nukleus:begin.ext [0xFF]
+read nukleus:begin.ext 0
+
+connected
+
+write nukleus:begin.ext 4s "test"
+write nukleus:begin.ext 1 ${kafka:varint(0)}
+write nukleus:begin.ext -1
+write nukleus:begin.ext [0xFF]
+write nukleus:begin.ext 0
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(1)}
+write nukleus:data.ext 4 "key1"
+write "Hello, world"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(2)}
+write nukleus:data.ext 4 "key2"
+write "Hello second"
+write flush
+
+write nukleus:data.ext ${newTimestamp} 1 ${kafka:varint(3)}
+write nukleus:data.ext 4 "key3"
+write "Hello, third"
+write flush

--- a/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/kafka/FetchIT.java
@@ -331,6 +331,17 @@ public class FetchIT
 
     @Test
     @Specification(
+    {"${scripts}/compacted.messages.slow.consumer/client",
+     "${scripts}/compacted.messages.slow.consumer/server"})
+    public void shouldReceivedMessagesFromCompactedTopicOnLiveStream() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification(
     {"${scripts}/compacted.messages.tombstone.repeated/client",
      "${scripts}/compacted.messages.tombstone.repeated/server"})
     public void shouldReceiveRepeatedTombstoneMessagesFromCompactedTopic() throws Exception

--- a/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/kafka/streams/FetchIT.java
@@ -257,6 +257,17 @@ public class FetchIT
 
     @Test
     @Specification({
+        "${scripts}/compacted.messages.slow.consumer/client",
+        "${scripts}/compacted.messages.slow.consumer/server"})
+    public void shouldReceiveCompactedMessagesWithLimitedWindow() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/compacted.messages.with.null.key/client",
         "${scripts}/compacted.messages.with.null.key/server"})
     public void shouldReceiveCompactedMessagesWithNullKey() throws Exception


### PR DESCRIPTION
A new test was added and another test was altered because the improved use of the cache means a  live fetch request no longer needs to be repeated