### PR TITLE
Update pom.xml to support new maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <k3po.version>3.0.0-alpha-102</k3po.version>
     <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.41</nukleus.plugin.version>
     <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <k3po.version>3.0.0-alpha-102</k3po.version>
     <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.41</nukleus.plugin.version>
+    <nukleus.plugin.version>0.42</nukleus.plugin.version>
     <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
 
     <junit.version>4.12</junit.version>
 
-    <k3po.version>3.0.0-alpha-102</k3po.version>
-    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
+    <k3po.version>3.0.0-alpha-103</k3po.version>
+    <k3po.nukleus.ext.version>0.50</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.42</nukleus.plugin.version>
-    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>0.40</nukleus.tcp.spec.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <k3po.nukleus.ext.version>0.50</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.42</nukleus.plugin.version>
-    <nukleus.tcp.spec.version>0.40</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>0.55</nukleus.tcp.spec.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <k3po.version>3.0.0-alpha-102</k3po.version>
     <k3po.nukleus.ext.version>0.48</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.40</nukleus.plugin.version>
-    <nukleus.tcp.spec.version>0.53</nukleus.tcp.spec.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <junit.version>4.12</junit.version>
 
     <k3po.version>3.0.0-alpha-102</k3po.version>
-    <k3po.nukleus.ext.version>0.48</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
     <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>

--- a/src/main/resources/META-INF/reaktivity/kafka.idl
+++ b/src/main/resources/META-INF/reaktivity/kafka.idl
@@ -27,7 +27,7 @@ scope kafka
         struct KafkaRouteEx
         {
             string16 topicName;
-            list<kafka::KafkaHeader> headers;
+            KafkaHeader[] headers;
         }
     }
 
@@ -41,7 +41,7 @@ scope kafka
             octets[fetchKeySize] fetchKey = null;
             int8 fetchKeyHashCount;
             int32[fetchKeyHashCount] fetchKeyHash = null;
-            list<kafka::KafkaHeader> headers;
+            KafkaHeader[] headers;
         }
 
         struct KafkaDataEx extends core::stream::Extension


### PR DESCRIPTION
Updated `kafka.idl` to replace list syntax (e.g. `list<XXX> fieldName`) with array syntax (e.g. `XXX[] fieldName`.